### PR TITLE
✨ Add support for modules with `__main__.py`

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -151,6 +151,7 @@ def dev(
     - [blue]app/main.py[/blue]
     - [blue]app/app.py[/blue]
     - [blue]app/api.py[/blue]
+    - [blue]app/__main__.py[/blue]
 
     It also detects the directory that needs to be added to the [bold]PYTHONPATH[/bold] to make the app importable and adds it.
 

--- a/src/fastapi_cli/discover.py
+++ b/src/fastapi_cli/discover.py
@@ -36,6 +36,9 @@ def get_default_path() -> Path:
     path = Path("app/api.py")
     if path.is_file():
         return path
+    path = Path("app/__main__.py")
+    if path.is_file():
+        return path
     raise FastAPICLIException(
         "Could not find a default file to run, please provide an explicit path"
     )


### PR DESCRIPTION
Some projects use `__main__.py` as the default module entry point:
https://docs.python.org/3/library/__main__.html#main-py-in-python-packages

It would be nice to support it out of the box