### PR TITLE
Added the optional workers flag

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -51,6 +51,7 @@ def _run(
     host: str = "127.0.0.1",
     port: int = 8000,
     reload: bool = True,
+    workers: Union[int, None] = None,
     root_path: str = "",
     command: str,
     app: Union[str, None] = None,
@@ -85,6 +86,7 @@ def _run(
         host=host,
         port=port,
         reload=reload,
+        workers=workers,
         root_path=root_path,
         proxy_headers=proxy_headers,
     )
@@ -117,6 +119,12 @@ def dev(
             help="Enable auto-reload of the server when (code) files change. This is [bold]resource intensive[/bold], use it only during development."
         ),
     ] = True,
+    workers: Annotated[
+        Union[int, None],
+        typer.Option(
+            help="Use multiple worker processes. Mutually exclusive with the --reload flag."
+        ),
+    ] = None,
     root_path: Annotated[
         str,
         typer.Option(
@@ -166,6 +174,7 @@ def dev(
         host=host,
         port=port,
         reload=reload,
+        workers=workers,
         root_path=root_path,
         app=app,
         command="dev",
@@ -200,6 +209,12 @@ def run(
             help="Enable auto-reload of the server when (code) files change. This is [bold]resource intensive[/bold], use it only during development."
         ),
     ] = False,
+    workers: Annotated[
+        Union[int, None],
+        typer.Option(
+            help="Use multiple worker processes. Mutually exclusive with the --reload flag."
+        ),
+    ] = None,
     root_path: Annotated[
         str,
         typer.Option(
@@ -249,6 +264,7 @@ def run(
         host=host,
         port=port,
         reload=reload,
+        workers=workers,
         root_path=root_path,
         app=app,
         command="run",


### PR DESCRIPTION
Support specifying the number of uvicorn workers. The flag is mutually exclusive with the reload flag, and uvicorn already does the right thing about displaying the warning that it is ignored if used together.