### PR TITLE
Enable configuration via pyproject.toml and environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "typer >= 0.12.3",
+    "tomli >= 2.0.1; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -13,6 +13,7 @@ from fastapi_cli.discover import get_import_string
 from fastapi_cli.exceptions import FastAPICLIException
 
 from . import __version__
+from .config import CommandWithProjectConfig
 from .logging import setup_logging
 
 app = typer.Typer(rich_markup_mode="rich")
@@ -92,12 +93,13 @@ def _run(
     )
 
 
-@app.command()
+@app.command(cls=CommandWithProjectConfig)
 def dev(
     path: Annotated[
         Union[Path, None],
         typer.Argument(
-            help="A path to a Python file or package directory (with [blue]__init__.py[/blue] files) containing a [bold]FastAPI[/bold] app. If not provided, a default set of paths will be tried."
+            help="A path to a Python file or package directory (with [blue]__init__.py[/blue] files) containing a [bold]FastAPI[/bold] app. If not provided, a default set of paths will be tried.",
+            envvar=["FASTAPI_DEV_PATH", "FASTAPI_PATH"],
         ),
     ] = None,
     *,
@@ -175,12 +177,13 @@ def dev(
     )
 
 
-@app.command()
+@app.command(cls=CommandWithProjectConfig)
 def run(
     path: Annotated[
         Union[Path, None],
         typer.Argument(
-            help="A path to a Python file or package directory (with [blue]__init__.py[/blue] files) containing a [bold]FastAPI[/bold] app. If not provided, a default set of paths will be tried."
+            help="A path to a Python file or package directory (with [blue]__init__.py[/blue] files) containing a [bold]FastAPI[/bold] app. If not provided, a default set of paths will be tried.",
+            envvar=["FASTAPI_RUN_PATH", "FASTAPI_PATH"],
         ),
     ] = None,
     *,
@@ -266,4 +269,4 @@ def run(
 
 
 def main() -> None:
-    app()
+    app(auto_envvar_prefix="FASTAPI")

--- a/src/fastapi_cli/config.py
+++ b/src/fastapi_cli/config.py
@@ -37,10 +37,6 @@ def read_pyproject_file(keys: Sequence[str]) -> dict[str, Any] | None:
 class CommandWithProjectConfig(TyperCommand):
     """Command class which loads parameters from a pyproject.toml file.
 
-    It will search the current directory and all parent directories for
-    a `pyproject.toml` file, then change directories to that file so all paths
-    defined in it remain relative to it.
-
     The table `tool.fastapi.cli` will be used. An additional subtable for the
     running command will also be used. e.g. `tool.fastapi.cli.dev`. Options
     on subcommand tables will override options from the cli table.

--- a/src/fastapi_cli/config.py
+++ b/src/fastapi_cli/config.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from click import BadParameter, Context
+from typer.core import TyperCommand
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+logger = logging.getLogger(__name__)
+
+
+def get_toml_key(config: dict[str, Any], keys: Sequence[str]) -> dict[str, Any]:
+    for key in keys:
+        config = config.get(key, {})
+    return config
+
+
+def read_pyproject_file(keys: Sequence[str]) -> dict[str, Any] | None:
+    path = Path("pyproject.toml")
+    if not path.exists():
+        return None
+
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+
+    config = get_toml_key(data, keys)
+    return config or None
+
+
+class CommandWithProjectConfig(TyperCommand):
+    """Command class which loads parameters from a pyproject.toml file.
+
+    It will search the current directory and all parent directories for
+    a `pyproject.toml` file, then change directories to that file so all paths
+    defined in it remain relative to it.
+
+    The table `tool.fastapi.cli` will be used. An additional subtable for the
+    running command will also be used. e.g. `tool.fastapi.cli.dev`. Options
+    on subcommand tables will override options from the cli table.
+
+    Example:
+
+    ```toml
+    [tool.fastapi.cli]
+    path = "asgi.py"
+    app = "application"
+
+    [tool.fastapi.cli.dev]
+    host = "0.0.0.0"
+    port = 5000
+
+    [tool.fastapi.cli.run]
+    reload = true
+    ```
+    """
+
+    toml_keys = ("tool", "fastapi", "cli")
+
+    def load_config_table(
+        self,
+        ctx: Context,
+        config: dict[str, Any],
+        config_path: str | None = None,
+    ) -> None:
+        if config_path is not None:
+            config = config.get(config_path, {})
+        if not config:
+            return
+        for param in ctx.command.params:
+            param_name = param.name or ""
+            if param_name in config:
+                try:
+                    value = param.type_cast_value(ctx, config[param_name])
+                except (TypeError, BadParameter) as e:
+                    keys: list[str] = list(self.toml_keys)
+                    if config_path is not None:
+                        keys.append(config_path)
+                    keys.append(param_name)
+                    full_path = ".".join(keys)
+                    ctx.fail(f"Error parsing pyproject.toml: key '{full_path}': {e}")
+                else:
+                    ctx.params[param_name] = value
+
+    def invoke(self, ctx: Context) -> Any:
+        config = read_pyproject_file(self.toml_keys)
+        if config is not None:
+            logger.info("Loading configuration from pyproject.toml")
+            command_name = ctx.command.name or ""
+            self.load_config_table(ctx, config)
+            self.load_config_table(ctx, config, command_name)
+
+        return super().invoke(ctx)

--- a/tests/assets/projects/configured_app/pyproject.toml
+++ b/tests/assets/projects/configured_app/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.fastapi.cli]
+path = "server.py"
+app = "application"

--- a/tests/assets/projects/configured_app/server.py
+++ b/tests/assets/projects/configured_app/server.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+application = FastAPI()
+
+
+@application.get("/")
+def app_root():
+    return {"message": "configured app"}

--- a/tests/assets/projects/configured_app_subtable/app.py
+++ b/tests/assets/projects/configured_app_subtable/app.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def app_root():
+    return {"message": "configured app with subcommand config"}

--- a/tests/assets/projects/configured_app_subtable/pyproject.toml
+++ b/tests/assets/projects/configured_app_subtable/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.fastapi.cli]
+# global option
+port = 8001
+
+[tool.fastapi.cli.run]
+reload = true
+workers = 4
+
+[tool.fastapi.cli.dev]
+# overrides global option
+port = 8002


### PR DESCRIPTION
This change allows configuration using both environment variables and a `pyproject.toml` file.

## Environment variables

This takes advantage of the builtin functionality in click for loading options from environment variables. The prefix is `FASTAPI`.

Example:
```sh
$ export FASTAPI_DEV_PATH="server/app.py" FASTAPI_DEV_PORT="8001"
$ fastapi dev
```

Environment variables for each option are listed in the `--help` text.

## Project configuration

If a `pyproject.toml` file exists in the current directory and contains the table `tool.fastapi.cli`, its keys will be merged into the click parameters. If a subtable matching the command exists, its keys will also be merged into the parameters, allowing for more precise configuration.

Example:

```toml
[tool.fastapi.cli]
app = "server/app.py"

[tool.fastapi.cli.run]
workers = 4
```