### PR TITLE
🔧 Make FastAPI and Uvicorn optional dependencies, to avoid circular dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,12 @@ source-includes = [
 name = "fastapi-cli-slim"
 
 [tool.tiangolo._internal-slim-build.packages.fastapi-cli]
-include-optional-dependencies = ["standard"]
+# No default dependencies included for now
+include-optional-dependencies = []
 
 [tool.tiangolo._internal-slim-build.packages.fastapi-cli.project]
-optional-dependencies = {}
+# No custom optional dependencies for now
+# optional-dependencies = {}
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Union
 
 import typer
-import uvicorn
 from rich import print
 from rich.padding import Padding
 from rich.panel import Panel
@@ -19,6 +18,11 @@ app = typer.Typer(rich_markup_mode="rich")
 
 setup_logging()
 logger = getLogger(__name__)
+
+try:
+    import uvicorn
+except ImportError:
+    uvicorn = None  # type: ignore[assignment]
 
 
 def version_callback(value: bool) -> None:
@@ -81,6 +85,10 @@ def _run(
             style="green",
         )
     print(Padding(panel, 1))
+    if not uvicorn:
+        raise FastAPICLIException(
+            "Could not import Uvicorn, try running 'pip install uvicorn'"
+        ) from None
     uvicorn.run(
         app=use_uvicorn_app,
         host=host,

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -21,7 +21,7 @@ logger = getLogger(__name__)
 
 try:
     import uvicorn
-except ImportError:
+except ImportError:  # pragma: no cover
     uvicorn = None  # type: ignore[assignment]
 
 

--- a/src/fastapi_cli/discover.py
+++ b/src/fastapi_cli/discover.py
@@ -5,7 +5,6 @@ from logging import getLogger
 from pathlib import Path
 from typing import Union
 
-from fastapi import FastAPI
 from rich import print
 from rich.padding import Padding
 from rich.panel import Panel
@@ -15,6 +14,11 @@ from rich.tree import Tree
 from fastapi_cli.exceptions import FastAPICLIException
 
 logger = getLogger(__name__)
+
+try:
+    from fastapi import FastAPI
+except ImportError:
+    FastAPI = None  # type: ignore[misc, assignment]
 
 
 def get_default_path() -> Path:
@@ -107,6 +111,10 @@ def get_app_name(*, mod_data: ModuleData, app_name: Union[str, None] = None) -> 
             "Ensure all the package directories have an [blue]__init__.py[/blue] file"
         )
         raise
+    if not FastAPI:  # type: ignore[truthy-function]
+        raise FastAPICLIException(
+            "Could not import FastAPI, try running 'pip install fastapi'"
+        ) from None
     object_names = dir(mod)
     object_names_set = set(object_names)
     if app_name:

--- a/src/fastapi_cli/discover.py
+++ b/src/fastapi_cli/discover.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 
 try:
     from fastapi import FastAPI
-except ImportError:
+except ImportError:  # pragma: no cover
     FastAPI = None  # type: ignore[misc, assignment]
 
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -16,7 +16,7 @@ def test_no_uvicorn() -> None:
     import fastapi_cli.cli
     import uvicorn
 
-    fastapi_cli.cli.uvicorn = None  # type: ignore[attr-defined]
+    fastapi_cli.cli.uvicorn = None  # type: ignore[attr-defined, assignment]
 
     with changing_dir(assets_path):
         result = runner.invoke(fastapi_cli.cli.app, ["dev", "single_file_app.py"])
@@ -34,7 +34,7 @@ def test_no_fastapi() -> None:
     import fastapi_cli.discover
     from fastapi import FastAPI
 
-    fastapi_cli.discover.FastAPI = None  # type: ignore[attr-defined]
+    fastapi_cli.discover.FastAPI = None  # type: ignore[attr-defined, assignment]
     with changing_dir(assets_path):
         with pytest.raises(FastAPICLIException) as exc_info:
             get_import_string(path=Path("single_file_app.py"))

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+from fastapi_cli.discover import get_import_string
+from fastapi_cli.exceptions import FastAPICLIException
+from typer.testing import CliRunner
+
+from .utils import changing_dir
+
+runner = CliRunner()
+
+assets_path = Path(__file__).parent / "assets"
+
+
+def test_no_uvicorn() -> None:
+    import fastapi_cli.cli
+    import uvicorn
+
+    fastapi_cli.cli.uvicorn = None  # type: ignore[attr-defined]
+
+    with changing_dir(assets_path):
+        result = runner.invoke(fastapi_cli.cli.app, ["dev", "single_file_app.py"])
+        assert result.exit_code == 1
+        assert result.exception is not None
+        assert (
+            "Could not import Uvicorn, try running 'pip install uvicorn'"
+            in result.exception.args[0]
+        )
+
+    fastapi_cli.cli.uvicorn = uvicorn  # type: ignore[attr-defined]
+
+
+def test_no_fastapi() -> None:
+    import fastapi_cli.discover
+    from fastapi import FastAPI
+
+    fastapi_cli.discover.FastAPI = None  # type: ignore[attr-defined]
+    with changing_dir(assets_path):
+        with pytest.raises(FastAPICLIException) as exc_info:
+            get_import_string(path=Path("single_file_app.py"))
+        assert "Could not import FastAPI, try running 'pip install fastapi'" in str(
+            exc_info.value
+        )
+
+    fastapi_cli.discover.FastAPI = FastAPI  # type: ignore[attr-defined]


### PR DESCRIPTION
🔧 Make FastAPI and Uvicorn optional dependencies, to avoid circular dependencies

This should handle: https://github.com/tiangolo/fastapi/discussions/11529