### PR TITLE
👷 Enable CI tests for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
       fail-fast: false
     steps:
       - name: Dump GitHub context


### PR DESCRIPTION
👷 Enable CI tests for Python 3.12